### PR TITLE
Annotation-based API proposal 1

### DIFF
--- a/Annotation-based API/proposal1/README.md
+++ b/Annotation-based API/proposal1/README.md
@@ -1,0 +1,8 @@
+# Annotation-based consumer and client API - proposal 1
+
+This proposal is based on the proposals in the https://github.com/tomitribe/jms-proposals repository.
+
+The gist of the proposal:
+
+* The consumer part is exemplified in the `NotificationsListener` and `BuildAndNotify` classes, which are annotated by `@MessageConsumer` and their method annotated by `@TopicListener` or `QueueListener` annotations
+* The client part is exemplified in the `BuildAndNotify` class, which uses the `MessagingClientBuilder` builder to build an implementation of an interface (`NotificationsClient`). The `NotificationsClient` is a client interface which defines that how the client object should be built. Each method and its parameters are annotated to specify the target queue or topic and how to convert arguments to a message.

--- a/Annotation-based API/proposal1/pom.xml
+++ b/Annotation-based API/proposal1/pom.xml
@@ -1,0 +1,51 @@
+<!--
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.eclipse.jms.proposals</groupId>
+    <artifactId>jms-annotation-based-api-proposal-1</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.jms</groupId>
+            <artifactId>jakarta.jms-api</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>8.0</version>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <optimize>true</optimize>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/AutoAcknowledge.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/AutoAcknowledge.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.jms;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation specifies that a callback method on a JMS message-driven bean must receive messages with an
+ * acknowledgement type of auto-acknowledge. It may be specified either on the callback method or on the message-driven
+ * bean class.
+ * <p>
+ * The message-driven bean must also be configured to use a transaction management type of BEAN. This may be configured
+ * by specifying the annotation {code @TransactionManagement(value=TransactionManagementType.BEAN)} on the
+ * message-driven bean. If a transaction management type of BEAN is not configured then it is recommended that
+ * deployment will fail.
+ * <p>
+ * If this annotation is specified on a method of a message-driven bean class then that method must also be annotated
+ * with {@code QueueListener} or {@code TopicListener}. If it is not then deployment will fail.
+ * <p>
+ * If this annotation is specified on the message-driven bean class then at least one method must be annotated with
+ * {@code QueueListener} or {@code TopicListener}. If no method is annotated with {@code QueueListener} or
+ * {@code TopicListener} then deployment will fail.
+ * <p>
+ * If either this annotation or {@code DupsOKAcknowledge} are specified on both a method of a message-driven bean class
+ * and on the message-driven bean class itself then deployment will fail.
+ *
+ * @see QueueListener
+ * @see TopicListener
+ * @see DupsOKAcknowledge
+ *
+ * @version JMS 2.1
+ * @since JMS 2.1
+ *
+ */
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface AutoAcknowledge {
+
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/ClientId.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/ClientId.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.jms;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation specifies that a callback method on a JMS message-driven bean must use the specified client
+ * identifier.
+ * <p>
+ * The method must also be annotated with either {@code TopicListener} or {@code QueueListener}. If it is not then
+ * deployment will fail.
+ * <p>
+ *
+ * @see TopicListener
+ * @see QueueListener
+ *
+ * @version JMS 2.1
+ * @since JMS 2.1
+ *
+ */
+@Retention(RUNTIME)
+@Target({METHOD})
+public @interface ClientId {
+
+    /**
+     * The client identifier that will be used.
+     *
+     * @return The client identifier that will be used.
+     */
+    String value();
+
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/DupsOKAcknowledge.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/DupsOKAcknowledge.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.jms;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation specifies that a callback method on a JMS message-driven bean must receive messages with an
+ * acknowledgement type of dups-ok-acknowledge. It may be specified either on the callback method or on the
+ * message-driven bean class.
+ *
+ * <p>
+ * The message-driven bean must also be configured to use a transaction management type of BEAN. This may be configured
+ * by specifying the annotation {code @TransactionManagement(value=TransactionManagementType.BEAN)} on the
+ * message-driven bean. If a transaction management type of BEAN is not configured then it is recommended that
+ * deployment will fail.
+ *
+ * <p>
+ * If this annotation is specified on a method of a message-driven bean class then that method must also be annotated
+ * with {@code QueueListener} or {@code TopicListener}. If it is not then deployment will fail.
+ *
+ * <p>
+ * If this annotation is specified on the message-driven bean class then at least one method must be annotated with
+ * {@code QueueListener} or {@code TopicListener}. If no method is annotated with {@code QueueListener} or
+ * {@code TopicListener} then deployment will fail.
+ *
+ * <p>
+ * If either this annotation or {@code AutoAcknowledge} are specified on both a method of a message-driven bean class
+ * and on the message-driven bean class itself then deployment will fail.
+ *
+ * @see QueueListener
+ * @see TopicListener
+ * @see DupsOKAcknowledge
+ *
+ * @version JMS 2.1
+ * @since JMS 2.1
+ *
+ */
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface DupsOKAcknowledge {
+
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/DurableSubscription.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/DurableSubscription.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.jms;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation specifies that a callback method on a JMS message-driven bean must use a durable subscription.
+ *
+ * <p>
+ * The method must also be annotated with {@code TopicListener}. If it is not then deployment will fail.
+ *
+ * @see TopicListener
+ *
+ * @version JMS 2.1
+ * @since JMS 2.1
+ *
+ */
+@Retention(RUNTIME)
+@Target({METHOD})
+public @interface DurableSubscription {
+
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/ListenerProperties.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/ListenerProperties.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.jms;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Containing annotation for annotations of type {@code ListenerProperty}.
+ *
+ * <p>
+ * This annotation is used internally when a method or class is annotated with more than one {@code ListenerProperty}
+ * annotation. Applications do not need to use this annotation directly.
+ *
+ * @see ListenerProperty
+ * @version JMS 2.1
+ * @since JMS 2.1
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface ListenerProperties {
+
+    ListenerProperty[] value();
+
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/ListenerProperty.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/ListenerProperty.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.jms;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation specifies an arbitrary activation property to be used by a callback method on a JMS message-driven
+ * bean must use the specified message selector. It may be specified either on the callback method or on the
+ * message-driven bean class.
+ *
+ * <p>
+ * If this annotation is specified on a method of a message-driven bean class then that method must also be annotated
+ * with {@code QueueListener} or {@code TopicListener}. If it is not then deployment will fail.
+ *
+ * <p>
+ * If this annotation is specified on the message-driven bean class then at least one method must be annotated with
+ * {@code QueueListener} or {@code TopicListener}. If no method is annotated with {@code QueueListener} or
+ * {@code TopicListener} then deployment will fail.
+ *
+ * <p>
+ * If this annotation is used to specify the same property on both a method of a message-driven bean class and on the
+ * message-driven bean class itself then deployment will fail.
+ *
+ * <p>
+ * Multiple {@code JMSListenerProperty} annotations may be used to set multiple properties on the same callback method.
+ *
+ * @version JMS 2.1
+ * @since JMS 2.1
+ */
+@Repeatable(ListenerProperties.class)
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface ListenerProperty {
+
+    /**
+     * Name of the activation property
+     *
+     * @return The name of the activation property
+     */
+    String name();
+
+    /**
+     * Value of the activation property
+     *
+     * @return The value of the activation property
+     */
+    String value();
+
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/MessageConsumer.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/MessageConsumer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.jms;
+
+import jakarta.resource.spi.ConnectorDrivenBean;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation replaces the proposed JMSMessageDrivenBean interface
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+@ConnectorDrivenBean
+public @interface MessageConsumer {
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/MessageHeader.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/MessageHeader.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.jms;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Specifies that a callback method parameter must be set to the specified message header value. This annotation may be
+ * applied to parameters on a callback method on a JMS message-driven bean that has been annotated with the
+ * {@code JMSQueueListener} , {@code JMSNonDurableTopicListener} or {@code JMSDurableTopicListener} annotation.
+ *
+ * <p>
+ * The parameter type must match the header type as shown in the following table. If it does not then deployment will
+ * fail.
+ *
+ * <pre>
+ * +-------------------+------------------------------------------------+
+ * | Annotation                                     | Parameter         |
+ * |                                                | type              |
+ * +-------------------+------------------------------------------------+
+ * | @MessageHeader(Header.JMSCorrelationID)        | String            |
+ * | @MessageHeader(Header.JMSCorrelationIDAsBytes) | byte[]            |
+ * | @MessageHeader(Header.JMSDeliveryMode)         | Integer or int    |
+ * | @MessageHeader(Header.JMSDeliveryTime)         | Long or long      |
+ * | @MessageHeader(Header.JMSDestination)          | Destination       |
+ * | @MessageHeader(Header.JMSExpiration)           | Long or long      |
+ * | @MessageHeader(Header.JMSMessageID)            | String            |
+ * | @MessageHeader(Header.JMSPriority)             | Integer or int    |
+ * | @MessageHeader(Header.JMSRedelivered)          | Boolean or boolean|
+ * | @MessageHeader(Header.JMSReplyTo)              | Destination       |
+ * | @MessageHeader(Header.JMSTimestamp)            | Long or long      |
+ * | @MessageHeader(Header.JMSType)                 | String            |
+ * | @MessageHeader(Header.JMSContentType)          | String            |
+ * +-------------------+------------------------------------------------+
+ * </pre>
+ *
+ * @version JMS 2.1
+ * @since JMS 2.1
+ *
+ * @see MessageProperty
+ *
+ */
+@Target(PARAMETER)
+@Retention(RUNTIME)
+public @interface MessageHeader {
+
+    /**
+     * Specifies the header field to be used
+     *
+     * @return The header field to be used
+     */
+    Header value();
+
+    public enum Header {
+        JMSCorrelationID, JMSCorrelationIDAsBytes, JMSDeliveryMode, JMSDeliveryTime, JMSDestination, JMSExpiration, JMSMessageID, JMSPriority, JMSRedelivered, JMSReplyTo, JMSTimestamp, JMSType, JMSContentType
+    }
+
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/MessageProperty.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/MessageProperty.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.jms;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Specifies that a callback method parameter must be set to the specified message property value. This annotation may
+ * be applied to parameters on a callback method on a JMS message-driven bean that has been annotated with the
+ * {@code JMSQueueListener} , {@code JMSNonDurableTopicListener} or {@code JMSDurableTopicListener} annotation.
+ *
+ * <p>
+ * The parameter must have a type appropriate to the specified property.
+ *
+ * <p>
+ * The method that will be used by the application server or resource adapter to obtain the property value will depend
+ * on the parameter type. The table below defines the method that will be used to obtain the value of a parameter
+ * annotated with {@code @MessageProperty("foo")}.
+ *
+ * <p>
+ * If the method parameter is not one of the types listed then deployment must fail.
+ *
+ * <pre>
+ * +-------------------------------------------------------+
+ * | Parameter | Set to                                    |
+ * | type      |                                           |
+ * +-----------+-------------------------------------------+
+ * | boolean   | message.getBooleanProperty("foo")         |
+ * | Boolean   | (Boolean)message.getObjectProperty("foo") |
+ * | byte      | message.getByteProperty("foo")            |
+ * | Byte      | (Byte)message.getObjectProperty("foo")    |
+ * | short     | message.getShortProperty("foo")           |
+ * | Short     | (Short)message.getObjectProperty("foo")   |
+ * | int       | message.getIntProperty("foo")             |
+ * | Integer   | (Integer)message.getObjectProperty("foo") |
+ * | long      | message.getLongProperty("foo")            |
+ * | Long      | (Long)message.getObjectProperty("foo")    |
+ * | float     | message.getFloatProperty("foo")           |
+ * | Float     | (Float)message.getObjectProperty("foo")   |
+ * | double    | message.getFloatProperty("foo")           |
+ * | Double    | (Double)message.getObjectProperty("foo")  |
+ * | String    | message.getStringProperty("foo")          |
+ * |-------------------------------------------------------+
+ * </pre>
+ *
+ * <p>
+ * Note that only {@code getObjectProperty} and {@code getStringObject} can return a null value. This means that if the
+ * specified property is not set then the parameter must be an object type ({@code Boolean}, {@code Byte},
+ * {@code Short}, {@code Integer}, {@code Long}, {@code Float}, {@code Double} or {@code String}), in which case the
+ * parameter will be set to null. *
+ *
+ * @see MessageHeader
+ *
+ * @version JMS 2.1
+ * @since JMS 2.1
+ */
+@Target(PARAMETER)
+@Retention(RUNTIME)
+public @interface MessageProperty {
+
+    /**
+     * Specifies the name of the message property to be used
+     *
+     * @return The name of the message property to be used
+     */
+    String value();
+
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/MessageSelector.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/MessageSelector.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.jms;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation specifies that a callback method on a JMS message-driven bean must use the specified message
+ * selector. It may be specified either on the callback method or on the message-driven bean class.
+ *
+ * <p>
+ * If this annotation is specified on a method of a message-driven bean class then that method must also be annotated
+ * with {@code QueueListener} or {@code TopicListener}. If it is not then deployment will fail.
+ *
+ * <p>
+ * If this annotation is specified on the message-driven bean class then at least one method must be annotated with
+ * {@code QueueListener} or {@code TopicListener}. If no method is annotated with {@code QueueListener} or
+ * {@code TopicListener} then deployment will fail.
+ *
+ * <p>
+ * If this annotation is specified on both a method of a message-driven bean class and on the message-driven bean class
+ * itself then deployment will fail.
+ *
+ * @see QueueListener
+ * @see TopicListener
+ *
+ * @version JMS 2.1
+ * @since JMS 2.1
+ */
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface MessageSelector {
+
+    /**
+     * The message selector that will be used.
+     *
+     * @return The message selector that will be used.
+     */
+    String value();
+
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/MessagingClientBuilder.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/MessagingClientBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jakarta.jms;
+
+import javax.ws.rs.core.Configurable;
+
+public interface MessagingClientBuilder extends Configurable<MessagingClientBuilder> {
+
+    static MessagingClientBuilder newBuilder() {
+        return null;
+    }
+
+    MessagingClientBuilder connectionFactory(ConnectionFactory connectionFactory);
+
+    <T> T build(Class<T> clazz);
+
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/QueueListener.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/QueueListener.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.jms;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation designates a callback method on a JMS message-driven bean that will receive messages from a queue,
+ * and specifies the queue from which messages will be received.
+ *
+ * <p>
+ * This annotation may only be used if the JMS message-driven bean implements the {@code JMSMessageDrivenBean} marker
+ * interface and does not implement the {@code MessageListener} interface. If this annotation is used on a JMS
+ * message-driven bean that implements the {@code MessageListener} interface then deployment will fail.
+ *
+ * <p>
+ * Only one method may be designated as a callback method. If more than one method on a JMS message-driven bean is
+ * annotated with {@code QueueListener} or {@code TopicListener} then deployment will fail.
+ *
+ * @see MessageConsumer
+ * @see TopicListener
+ *
+ * @version JMS 2.1
+ * @since JMS 2.1
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface QueueListener {
+
+    /**
+     * Lookup name of the Queue from which messages will be received.
+     *
+     * @return The lookup name of the Queue.
+     */
+    String value();
+
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/SubscriptionName.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/SubscriptionName.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.jms;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation specifies that a callback method on a JMS message-driven bean that has been configured to consume
+ * messages from a topic using a durable subscription must use the specified durable subscription name.
+ *
+ * <p>
+ * The method must also be annotated with {@code TopicListener} and {@code DurableSubscription}. If it is not then
+ * deployment will fail.
+ *
+ * @see TopicListener
+ * @see DurableSubscription
+ *
+ * @version JMS 2.1
+ * @since JMS 2.1
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface SubscriptionName {
+
+    /**
+     * The subscription name that will be used.
+     *
+     * @return The subscription name.
+     */
+    String value();
+
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/jms/TopicListener.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/jms/TopicListener.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.jms;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation designates a callback method on a JMS message-driven bean that will receive messages from a topic,
+ * and specifies the topic from which messages will be received.
+ *
+ * <p>
+ * By default a non-durable subscription is used. The {@code DurableSubscription} annotation may be used in conjunction
+ * with this annotation to specify that a durable subscription is required.
+ *
+ * <p>
+ * This annotation may only be used if the JMS message-driven bean implements the {@code JMSMessageDrivenBean} marker
+ * interface and does not implement the {@code MessageListener} interface. If this annotation is used on a
+ * message-driven bean that implements the {@code MessageListener} interface then deployment will fail.
+ *
+ * <p>
+ * Only one method may be designated as a callback method. If more than one method on a JMS message-driven bean is
+ * annotated with {@code QueueListener} or {@code TopicListener} then deployment will fail.
+ *
+ * @see MessageConsumer
+ * @see QueueListener
+ * @see DurableSubscription
+ *
+ * @version JMS 2.1
+ * @since JMS 2.1
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface TopicListener {
+
+    /**
+     * Lookup name of the Topic from which messages will be received.
+     *
+     * @return The lookup name of the Topic.
+     */
+    String value() default "";
+
+}

--- a/Annotation-based API/proposal1/src/main/java/jakarta/resource/spi/ConnectorDrivenBean.java
+++ b/Annotation-based API/proposal1/src/main/java/jakarta/resource/spi/ConnectorDrivenBean.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.resource.spi;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Potential annotation that can be used on annotated versions
+ * of the Connector Architecture's Message Listener interface
+ */
+@Retention(RUNTIME)
+@Target(ANNOTATION_TYPE)
+public @interface ConnectorDrivenBean {
+}

--- a/Annotation-based API/proposal1/src/test/java/io/breezmq/MaxMessagesPerSession.java
+++ b/Annotation-based API/proposal1/src/test/java/io/breezmq/MaxMessagesPerSession.java
@@ -1,0 +1,26 @@
+/*
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package io.breezmq;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MaxMessagesPerSession {
+    int value();
+}

--- a/Annotation-based API/proposal1/src/test/java/io/breezmq/MaxSessions.java
+++ b/Annotation-based API/proposal1/src/test/java/io/breezmq/MaxSessions.java
@@ -1,0 +1,26 @@
+/*
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package io.breezmq;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MaxSessions {
+    int value();
+}

--- a/Annotation-based API/proposal1/src/test/java/org/example/BuildAndNotify.java
+++ b/Annotation-based API/proposal1/src/test/java/org/example/BuildAndNotify.java
@@ -1,0 +1,64 @@
+/*
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.example;
+
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageHeader;
+import jakarta.jms.MessagingClientBuilder;
+import jakarta.jms.QueueListener;
+import jakarta.jms.Topic;
+
+import javax.annotation.Resource;
+
+@MessageConsumer
+public class BuildAndNotify {
+
+    @Resource
+    private ConnectionFactory connectionFactory;
+
+    @QueueListener("PROJECT.BUILD")
+    public void buildProject(@MessageHeader(MessageHeader.Header.JMSReplyTo) final Topic buildNotifications,
+                             @MessageHeader(MessageHeader.Header.JMSCorrelationID) final String buildId,
+                             final Project project) throws JMSException {
+
+        final NotificationsClient notificationsClient = MessagingClientBuilder.newBuilder()
+                .connectionFactory(connectionFactory)
+                .build(NotificationsClient.class);
+
+        try {
+            build(project);
+
+            notificationsClient.processNotifications(
+                    buildId,
+                    project.getUrl(),
+                    "SUCCESS"
+            );
+
+        } catch (Exception e) {
+
+            notificationsClient.processNotifications(
+                    buildId,
+                    project.getUrl(),
+                    "FAIL"
+            );
+        }
+    }
+
+    private void build(final Project project) {
+
+    }
+
+}

--- a/Annotation-based API/proposal1/src/test/java/org/example/BuildId.java
+++ b/Annotation-based API/proposal1/src/test/java/org/example/BuildId.java
@@ -1,0 +1,9 @@
+package org.example;
+
+public class BuildId {
+    private final String string;
+
+    public BuildId(final String string) {
+        this.string = string;
+    }
+}

--- a/Annotation-based API/proposal1/src/test/java/org/example/BuildNotification.java
+++ b/Annotation-based API/proposal1/src/test/java/org/example/BuildNotification.java
@@ -1,0 +1,40 @@
+/*
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.example;
+
+import javax.json.bind.annotation.JsonbPropertyOrder;
+import javax.json.bind.config.PropertyOrderStrategy;
+
+@JsonbPropertyOrder(PropertyOrderStrategy.ANY)
+public class BuildNotification {
+
+    private Project project;
+    private String message;
+
+    public Project getProject() {
+        return project;
+    }
+
+    public void setProject(final Project project) {
+        this.project = project;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(final String message) {
+        this.message = message;
+    }
+}

--- a/Annotation-based API/proposal1/src/test/java/org/example/BuildTask.java
+++ b/Annotation-based API/proposal1/src/test/java/org/example/BuildTask.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.example;
+
+public class BuildTask {
+
+    private BuildId buildId;
+
+    private String task;
+
+    public BuildId getBuildId() {
+        return buildId;
+    }
+
+    public void setBuildId(final BuildId buildId) {
+        this.buildId = buildId;
+    }
+
+    public String getTask() {
+        return task;
+    }
+
+    public void setTask(final String task) {
+        this.task = task;
+    }
+}

--- a/Annotation-based API/proposal1/src/test/java/org/example/BuildTasksMessageListener.java
+++ b/Annotation-based API/proposal1/src/test/java/org/example/BuildTasksMessageListener.java
@@ -1,0 +1,46 @@
+/*
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.example;
+
+import io.breezmq.MaxMessagesPerSession;
+import io.breezmq.MaxSessions;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.QueueListener;
+import jakarta.jms.TopicListener;
+
+@MessageConsumer
+@MaxSessions(3)
+@MaxMessagesPerSession(1)
+public class BuildTasksMessageListener {
+
+    @QueueListener("TASK.QUEUE")
+    public void processBuildTask(final BuildTask buildTask) throws JMSException {
+
+        doSomethingUseful(buildTask);
+
+    }
+
+    @TopicListener("BUILD.TOPIC")
+    public void processBuildNotification(final BuildNotification notification) throws JMSException {
+
+        System.out.println("Something happened " + notification);
+    }
+
+
+    // This is the only "useful" code in the class
+    private void doSomethingUseful(BuildTask buildTask) {
+        System.out.println(buildTask);
+    }
+}

--- a/Annotation-based API/proposal1/src/test/java/org/example/NotificationsClient.java
+++ b/Annotation-based API/proposal1/src/test/java/org/example/NotificationsClient.java
@@ -1,0 +1,34 @@
+/*
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.example;
+
+import jakarta.jms.MessageProperty;
+import jakarta.jms.TopicListener;
+
+import java.net.URL;
+
+public interface NotificationsClient {
+
+    @TopicListener("BUILD.NOTIFICATIONS")
+    public void processNotifications(@MessageProperty("buildId") final String buildId,
+                                     @MessageProperty("projectUrl") final String projectUrl,
+                                     @MessageProperty("buildUrl") final String buildUrl,
+                                     @MessageProperty("buildStatus") final String buildStatus,
+                                     final String message);
+
+    @TopicListener("BUILD.NOTIFICATIONS")
+    public void processNotifications(@MessageProperty("buildId") final String buildId,
+                                     @MessageProperty("projectUrl") final URL projectUrl,
+                                     @MessageProperty("buildStatus") final String buildStatus);
+}

--- a/Annotation-based API/proposal1/src/test/java/org/example/NotificationsListener.java
+++ b/Annotation-based API/proposal1/src/test/java/org/example/NotificationsListener.java
@@ -1,0 +1,65 @@
+/*
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.example;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageProperty;
+import jakarta.jms.TopicListener;
+
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@MessageConsumer
+public class NotificationsListener {
+
+    private final Logger logger = Logger.getLogger(NotificationsListener.class.getName());
+
+    @TopicListener("BUILD.NOTIFICATIONS")
+    public void processNotifications(@MessageProperty("buildId") final String buildId,
+                                     @MessageProperty("date") final long date,
+                                     @MessageProperty("projectUrl") final String projectUrl,
+                                     @MessageProperty("buildUrl") final String buildUrl,
+                                     @MessageProperty("buildStatus") final String buildStatus,
+                                     final String message) {
+
+
+        if ("FAIL".equals(buildStatus)) {
+
+            logger.log(Level.SEVERE, String.format("Build Failed %s at %s: %s - details %s", buildId, date, buildUrl, message));
+
+        } else if ("SUCCESS".equals(buildStatus)) {
+
+            logger.log(Level.INFO, String.format("Build Succeeded %s at %s: %s - details %s", buildId, date, buildUrl, message));
+        }
+    }
+
+    @TopicListener("BUILD.NOTIFICATIONS")
+    public void processNotifications(@MessageProperty("buildId") final String buildId,
+                                     @MessageProperty("date") final long date,
+                                     @MessageProperty("projectUrl") final URL projectUrl,
+                                     @MessageProperty("buildStatus") final String buildStatus) throws JMSException {
+
+
+        if ("FAIL".equals(buildStatus)) {
+
+            logger.log(Level.SEVERE, String.format("Build Failed %s at %s", buildId, date));
+
+        } else if ("SUCCESS".equals(buildStatus)) {
+
+            logger.log(Level.INFO, String.format("Build Succeeded %s at %s", buildId, date));
+        }
+    }
+}

--- a/Annotation-based API/proposal1/src/test/java/org/example/Project.java
+++ b/Annotation-based API/proposal1/src/test/java/org/example/Project.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.example;
+
+import javax.json.bind.annotation.JsonbProperty;
+import javax.json.bind.annotation.JsonbPropertyOrder;
+import javax.json.bind.config.PropertyOrderStrategy;
+import java.net.URL;
+
+@JsonbPropertyOrder(PropertyOrderStrategy.ANY)
+public class Project {
+
+    @JsonbProperty("project-name")
+    private String name;
+
+    private URL url;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    public void setUrl(final URL url) {
+        this.url = url;
+    }
+}

--- a/Annotation-based API/proposal1/src/test/resources/sample-ra.xml
+++ b/Annotation-based API/proposal1/src/test/resources/sample-ra.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<connector xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/connector_1_7.xsd"
+           version="1.7">
+    <description>Breezmq Connector Resource Adapter</description>
+    <display-name>Breezmq Connector Resource Adapter</display-name>
+    <eis-type>Breezmq Adapter</eis-type>
+    <resourceadapter-version>1.0</resourceadapter-version>
+    <license>
+        <license-required>false</license-required>
+    </license>
+    <resourceadapter>
+        <resourceadapter-class>io.breezmq.adapter.BreezmqResourceAdapter</resourceadapter-class>
+        <config-property>
+            <config-property-name>port</config-property-name>
+            <config-property-type>java.lang.Integer</config-property-type>
+            <config-property-value>2222</config-property-value>
+        </config-property>
+        <inbound-resourceadapter>
+            <messageadapter>
+                <messagelistener>
+                    <messagelistener-type>jakarta.jms.MessageConsumer</messagelistener-type>
+                    <activationspec>
+                        <activationspec-class>io.breezmq.adapter.BreezmqActivationSpec</activationspec-class>
+                    </activationspec>
+                </messagelistener>
+            </messageadapter>
+        </inbound-resourceadapter>
+    </resourceadapter>
+</connector>


### PR DESCRIPTION
# Annotation-based consumer and client API - proposal 1 for https://github.com/eclipse-ee4j/jms-api/issues/249 and https://github.com/eclipse-ee4j/jms-api/issues/243

This proposal is based on the proposals in the https://github.com/tomitribe/jms-proposals repository.

The gist of the proposal:

* The consumer part is exemplified in the `NotificationsListener` and `BuildAndNotify` classes, which are annotated by `@MessageConsumer` and their method annotated by `@TopicListener` or `QueueListener` annotations
* The client part is exemplified in the `BuildAndNotify` class, which uses the `MessagingClientBuilder` builder to build an implementation of an interface (`NotificationsClient`). The `NotificationsClient` is a client interface which defines that how the client object should be built. Each method and its parameters are annotated to specify the target queue or topic and how to convert arguments to a message.